### PR TITLE
Fix:prf.htmlにて自己紹介がない場合の処理を修正

### DIFF
--- a/public/prf-input.html
+++ b/public/prf-input.html
@@ -94,7 +94,7 @@
                 }
 
                 alert("投稿完了！");
-                return;
+                window.location.href = "./prf.html";
             }
             catch (err) {
                 console.log(err);

--- a/public/prf.html
+++ b/public/prf.html
@@ -26,7 +26,11 @@
 
             const prf = await prf_result.json();
             document.getElementById("user_name").innerText += prf[0].user_name;
-            document.getElementById("self-intro").innerText += prf[0].self_intro;
+            if (prf[0].self_intro === null) {
+                document.getElementById("self-intro").innerText += "まだ書かれていないようです...";
+            } else {
+                document.getElementById("self-intro").innerText += prf[0].self_intro;
+            }
             localStorage.setItem("id", prf[0].id);
 
             var id = localStorage.getItem("id");


### PR DESCRIPTION
nullの場合「まだ書かれていないようです...」と表示
prf-inputにて入力後alertを消すとプロフィール画面に遷移